### PR TITLE
Update RNOsSettingsManager.podspec

### DIFF
--- a/ios/RNOsSettingsManager.podspec
+++ b/ios/RNOsSettingsManager.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNOsSettingsManager
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/dmbookpro/react-native-os-settings-manager/blob/master/README.md"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
The `RNOsSettingsManager` pod failed to validate due to 1 error:
  - ERROR | attributes: Missing required attribute `homepage

So I  added repo readme file as a home page to fix this issue and now it is working fine.